### PR TITLE
Adding webhook parameter on createInvoice

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -62,6 +62,7 @@ export class LNBitsWalletClass {
       amount: number;
       memo: string;
       out?: boolean;
+      webhook?: string;
     } = {
       amount: 0,
       memo: '',


### PR DESCRIPTION
`createInvoice` was missing the `webhook` parameter, which allows you to receive a webhook when an invoice is paid.